### PR TITLE
Change onie image link to release portal

### DIFF
--- a/platform/otn-kvm/onie.mk
+++ b/platform/otn-kvm/onie.mk
@@ -1,4 +1,5 @@
-ONIE_RECOVERY_IMAGE = onie-recovery-x86_64-otn-kvm_x86_64-r0.iso
-$(ONIE_RECOVERY_IMAGE)_URL = "https://raw.githubusercontent.com/sonic-otn/ot_kvm_onie/refs/heads/otn-kvm/$(ONIE_RECOVERY_IMAGE)"
+ONIE_RECOVERY_IMAGE_VER = r0
+ONIE_RECOVERY_IMAGE = onie-recovery-x86_64-otn-kvm_x86_64-$(ONIE_RECOVERY_IMAGE_VER).iso
+$(ONIE_RECOVERY_IMAGE)_URL = "https://github.com/sonic-otn/onie/releases/download/otn-kvm-$(ONIE_RECOVERY_IMAGE_VER)/$(ONIE_RECOVERY_IMAGE)"
 
 SONIC_ONLINE_FILES += $(ONIE_RECOVERY_IMAGE)


### PR DESCRIPTION

Change onie image link to standardize release portal instead of extenal repository link.
