### PR TITLE
 get the libsai, libhal and libhalplaformclient debs from release tag

### DIFF
--- a/platform/otn-kvm/hal-client.mk
+++ b/platform/otn-kvm/hal-client.mk
@@ -1,5 +1,5 @@
 HALCLIENT_VERSION = 1.0.0
 OTN_KVM_HALCLIENT_DEB = libhalplatformclient-otn-$(HALCLIENT_VERSION)-amd64.deb
-$(OTN_KVM_HALCLIENT_DEB)_URL = "https://raw.githubusercontent.com/sonic-otn/sonic-otn-libs/refs/heads/main/debs/$(OTN_KVM_HALCLIENT_DEB)"
+$(OTN_KVM_HALCLIENT_DEB)_URL = "$(OTN_LIBS_RELEASE_URL)/$(OTN_KVM_HALCLIENT_DEB)"
 
 SONIC_ONLINE_DEBS += $(OTN_KVM_HALCLIENT_DEB)

--- a/platform/otn-kvm/hal-server.mk
+++ b/platform/otn-kvm/hal-server.mk
@@ -1,6 +1,6 @@
 HALSERVER_VERSION = 1.1.0
 OTN_KVM_HALSERVER_DEB = libhal-otn-kvm-$(HALSERVER_VERSION)-amd64.deb
-$(OTN_KVM_HALSERVER_DEB)_URL = "https://raw.githubusercontent.com/sonic-otn/sonic-otn-libs/refs/heads/main/debs/$(OTN_KVM_HALSERVER_DEB)"
+$(OTN_KVM_HALSERVER_DEB)_URL = "$(OTN_LIBS_RELEASE_URL)/$(OTN_KVM_HALSERVER_DEB)"
 
 
 SONIC_ONLINE_DEBS += $(OTN_KVM_HALSERVER_DEB)

--- a/platform/otn-kvm/otn-libs-release.mk
+++ b/platform/otn-kvm/otn-libs-release.mk
@@ -1,0 +1,9 @@
+# OTN libs: fetch .debs from GitHub Releases
+# Publish debs at: https://github.com/sonic-otn/sonic-otn-libs/releases
+#
+# Tag = release/bundle identifier (not package version). Each .deb has its own
+# version in the filename (e.g. libsai-otn-1.2.0-amd64.deb).
+#   make OTN_LIBS_RELEASE_TAG=latest ...
+#   make OTN_LIBS_RELEASE_TAG=release-2024q1 ...
+OTN_LIBS_RELEASE_TAG ?= v1.1.0
+OTN_LIBS_RELEASE_URL = https://github.com/sonic-otn/sonic-otn-libs/releases/download/$(OTN_LIBS_RELEASE_TAG)

--- a/platform/otn-kvm/rules.mk
+++ b/platform/otn-kvm/rules.mk
@@ -1,3 +1,4 @@
+include $(PLATFORM_PATH)/otn-libs-release.mk
 include $(PLATFORM_PATH)/hal-server.mk
 include $(PLATFORM_PATH)/hal-client.mk
 include $(PLATFORM_PATH)/sai.mk

--- a/platform/otn-kvm/sai.mk
+++ b/platform/otn-kvm/sai.mk
@@ -1,5 +1,5 @@
 LIBSAI_VERSION = 1.1.0
 OTN_KVM_LIBSAI_DEB = libsai-otn-$(LIBSAI_VERSION)-amd64.deb
-$(OTN_KVM_LIBSAI_DEB)_URL = "https://raw.githubusercontent.com/sonic-otn/sonic-otn-libs/main/debs/$(OTN_KVM_LIBSAI_DEB)"
+$(OTN_KVM_LIBSAI_DEB)_URL = "$(OTN_LIBS_RELEASE_URL)/$(OTN_KVM_LIBSAI_DEB)"
 
 SONIC_ONLINE_DEBS += $(OTN_KVM_LIBSAI_DEB)


### PR DESCRIPTION
We want to get the libhal-otn-kvm-1.1.0-amd64.deb, libhalplatformclient-otn-1.0.0-amd64.deb and libsai-otn-1.1.0-amd64.deb from the release tag from repo https://github.com/sonic-otn/sonic-otn-libs.
Different tags can be selected by modifying the release tag name in the file otn-libs-release.mk 

