### PR TITLE
Add OTN attenuator and amplifier sonic yang model

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -223,6 +223,8 @@ yang_files = [
     'sonic-fast-linkup.yang',
     'sonic-alarm.yang',
     'sonic-event.yang',
+    'sonic-optical-amplifier.yang',
+    'sonic-optical-attenuator.yang',
 ]
 
 class my_build_py(build_py):

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -3296,6 +3296,31 @@
                 "mac_holdtime": "1000",
                 "neigh_holdtime": "600"
             }
+        },
+        "OTN_OA": {
+            "OA0-0": {
+                "type": "EDFA",
+                "target-gain": "15.0",
+                "min-gain": "5.0",
+                "max-gain": "25.0",
+                "target-gain-tilt": "0.0",
+                "gain-range": "LOW_GAIN_RANGE",
+                "amp-mode": "CONSTANT_GAIN",
+                "target-output-power": "23.0",
+                "max-output-power": "23.0",
+                "enabled": "true",
+                "fiber-type-profile": "SSMF"
+            }
+        },
+        "OTN_OSC": {
+            "OSC0-0": {}
+        },
+        "OTN_ATTENUATOR": {
+            "VOA0-0": {
+                "attenuation-mode": "CONSTANT_ATTENUATION",
+                "target-output-power": "5.0",
+                "attenuation": "10.0",
+                "enabled": "true"            }
         }
     },
     "SAMPLE_CONFIG_DB_UNKNOWN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/optical_amplifier.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/optical_amplifier.json
@@ -1,0 +1,9 @@
+{
+    "VALID_OTN_OA": {
+        "desc": "Load valid OTN_OA configuration"
+    },
+
+    "VALID_OTN_OSC": {
+        "desc": "Load valid OTN_OSC configuration"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/optical_attenuator.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/optical_attenuator.json
@@ -1,0 +1,5 @@
+{
+    "VALID_OTN_ATTENUATOR": {
+        "desc": "Load valid OTN_ATTENUATOR configuration"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_amplifier.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_amplifier.json
@@ -1,0 +1,36 @@
+{
+    "VALID_OTN_OA": {
+        "sonic-optical-amplifier:sonic-optical-amplifier": {
+            "sonic-optical-amplifier:OTN_OA": {
+                "OTN_OA_LIST": [
+                    {
+                        "name": "OA0-0",
+                        "type": "EDFA",
+                        "target-gain": "15.0",
+                        "min-gain": "5.0",
+                        "max-gain": "25.0",
+                        "target-gain-tilt": "0.0",
+                        "gain-range": "LOW_GAIN_RANGE",
+                        "amp-mode": "CONSTANT_GAIN",
+                        "target-output-power": "23.0",
+                        "max-output-power": "23.0",
+                        "enabled": true,
+                        "fiber-type-profile": "SSMF"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VALID_OTN_OSC": {
+        "sonic-optical-amplifier:sonic-optical-amplifier": {
+            "sonic-optical-amplifier:OTN_OSC": {
+                "OTN_OSC_LIST": [
+                    {
+                        "interface": "OSC0-0"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_attenuator.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_attenuator.json
@@ -1,0 +1,17 @@
+{
+    "VALID_OTN_ATTENUATOR": {
+        "sonic-optical-attenuator:sonic-optical-attenuator": {
+            "sonic-optical-attenuator:OTN_ATTENUATOR": {
+                "OTN_ATTENUATOR_LIST": [
+                    {
+                        "name": "VOA0-0",
+                        "attenuation-mode": "CONSTANT_ATTENUATION",
+                        "target-output-power": "5.0",
+                        "attenuation": "10.0",
+                        "enabled": true
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-optical-amplifier.yang
+++ b/src/sonic-yang-models/yang-models/sonic-optical-amplifier.yang
@@ -1,0 +1,136 @@
+module sonic-optical-amplifier {
+  yang-version 1.1;
+  namespace "http://github.com/sonic-net/sonic-optical-amplifier";
+  prefix opt-amp;
+
+  organization
+    "SONiC";
+  contact
+    "SONiC";
+  description
+    "OTN_OA and OTN_OSC YANG Module for SONiC OS";
+
+  revision 2026-06-01 {
+    description
+      "First revision, derived from openconfig-optical-amplifier.yang {version 2019-12-06}";
+  }
+
+  container sonic-optical-amplifier {
+    container OTN_OA {
+      description
+        "Enclosing container for list of amplifiers";
+      list OTN_OA_LIST {
+        key "name";
+        leaf name {
+          type string;
+          description
+            "User-defined name assigned to identify a specific amplifier
+             in the device";
+        }
+        leaf type {
+          type string;
+          description
+            "Type of the amplifier";
+        }
+        leaf target-gain {
+          type decimal64 {
+            range "0..max";
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "Positive gain applied by the amplifier. This is used
+             when the amp-mode is in CONSTANT_GAIN or DYNAMIC_GAIN
+             mode to set the target gain that the amplifier should
+             achieve.";
+        }
+        leaf min-gain {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "The minimum allowed gain of the amplifier. This is used
+             when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
+             to prevent the gain from dropping below a desired threshold.
+             If left empty, the platform will apply a minimum gain based
+             on hardware specifications.";
+        }
+        leaf max-gain {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "The maximum allowed gain of the amplifier. This is used
+             when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
+             to prevent the gain from exceeding a desired threshold. If
+             left empty, the platform will apply a maximum gain based on
+             hardware specifications.";
+        }
+        leaf target-gain-tilt {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "Gain tilt control";
+        }
+        leaf gain-range {
+          type string;
+          description
+            "Selected gain range.  The gain range is a platform-defined
+             value indicating the switched gain amplifier setting";
+        }
+        leaf amp-mode {
+          type string;
+          description
+            "The operating mode of the amplifier";
+        }
+        leaf target-output-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "Output optical power of the amplifier.";
+        }
+        leaf max-output-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "The maximum optical output power of the amplifier. This
+             may be used to prevent the output power from exceeding a
+             desired threshold.";
+        }
+        leaf enabled {
+          type boolean;
+          description
+            "Turns power on / off to the amplifiers gain module.";
+        }
+        leaf fiber-type-profile {
+          type string;
+          description
+            "The fiber type profile specifies details about the
+             fiber type which are needed to accurately determine
+             the gain and perform efficient amplification. This is
+             only needed for Raman type amplifiers.";
+        }
+      }
+    }
+    container OTN_OSC {
+      description
+        "Enclosing container for list of supervisory channels";
+      list OTN_OSC_LIST {
+        key "interface";
+        leaf interface {
+          type string;
+          description
+            "Reference to an OSC interface";
+        }
+      }
+    }
+  }
+}

--- a/src/sonic-yang-models/yang-models/sonic-optical-attenuator.yang
+++ b/src/sonic-yang-models/yang-models/sonic-optical-attenuator.yang
@@ -1,0 +1,64 @@
+module sonic-optical-attenuator {
+  yang-version 1.1;
+  namespace "http://github.com/sonic-net/sonic-optical-attenuator";
+  prefix opt-att;
+
+  organization
+    "SONiC";
+  contact
+    "SONiC";
+  description
+    "OTN_ATTENUATOR YANG Module for SONiC OS";
+
+  revision 2026-06-01 {
+    description
+      "First revision, derived from openconfig-optical-attenuator.yang {version 2019-07-19}";
+  }
+
+  container sonic-optical-attenuator {
+    container OTN_ATTENUATOR {
+      description
+        "Enclosing container for list of attenuators";
+      list OTN_ATTENUATOR_LIST {
+        key "name";
+        leaf name {
+          type string;
+          description
+            "User-defined name assigned to identify a specific attenuator
+             in the device";
+        }
+        leaf attenuation-mode {
+          type string;
+          description
+            "The operating mode of the attenuator";
+        }
+        leaf target-output-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "Power level set on the output of attenuator.  This leaf is
+             only relevant when in CONSTANT_POWER mode.";
+        }
+        leaf attenuation {
+          type decimal64 {
+            range "0..max";
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "Attenuation applied by the attenuator.  This leaf is only
+             relevant when in CONSTANT_ATTENUATION mode.";
+        }
+        leaf enabled {
+          type boolean;
+          description
+            "When true, attenuator is set to specified attenuation or varies to
+             maintain constant output power.  When false, the attenuator is set
+             max attenuation or blocked.";
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
These two sonic yang models are generated from `config` container of openconfig-optical-amplifier.yang and openconfig-optical-attenuator.yang. Two usages:
-  Since [commit](https://github.com/sonic-net/sonic-swss-common/commit/40feb900aabe97e1972b80cffc11cf2413c88fbd#diff-1d101f21f9c1725a002c730c62c84cf4b8615207602066783976e66435e13ff8), Config DB table names are autogenerated by sonic yang, instead of hard coded in schema.h. With this change, OTN-OA and OTN-ATTENUATOR table name would be generated in cfg_schema.h, which is included by schema.h.
- These two yang models will be imported to sonic-mgmt-common for NBI CVL (configuration validation layer)