### PR TITLE
Add OTN attenuator and amplifier sonic yang model

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -223,6 +223,8 @@ yang_files = [
     'sonic-fast-linkup.yang',
     'sonic-alarm.yang',
     'sonic-event.yang',
+    'sonic-optical-amplifier.yang',
+    'sonic-optical-attenuator.yang',
 ]
 
 class my_build_py(build_py):

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -3296,6 +3296,31 @@
                 "mac_holdtime": "1000",
                 "neigh_holdtime": "600"
             }
+        },
+        "OTN_OA": {
+            "OA0-0": {
+                "type": "EDFA",
+                "target-gain": "15.0",
+                "min-gain": "5.0",
+                "max-gain": "25.0",
+                "target-gain-tilt": "0.0",
+                "gain-range": "LOW_GAIN_RANGE",
+                "amp-mode": "CONSTANT_GAIN",
+                "target-output-power": "23.0",
+                "max-output-power": "23.0",
+                "enabled": "true",
+                "fiber-type-profile": "SSMF"
+            }
+        },
+        "OTN_OSC": {
+            "OSC0-0": {}
+        },
+        "OTN_ATTENUATOR": {
+            "VOA0-0": {
+                "attenuation-mode": "CONSTANT_ATTENUATION",
+                "target-output-power": "5.0",
+                "attenuation": "10.0",
+                "enabled": "true"            }
         }
     },
     "SAMPLE_CONFIG_DB_UNKNOWN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/optical_amplifier.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/optical_amplifier.json
@@ -1,0 +1,9 @@
+{
+    "VALID_OTN_OA": {
+        "desc": "Load valid OTN_OA configuration"
+    },
+
+    "VALID_OTN_OSC": {
+        "desc": "Load valid OTN_OSC configuration"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/optical_attenuator.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/optical_attenuator.json
@@ -1,0 +1,5 @@
+{
+    "VALID_OTN_ATTENUATOR": {
+        "desc": "Load valid OTN_ATTENUATOR configuration"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_amplifier.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_amplifier.json
@@ -1,0 +1,36 @@
+{
+    "VALID_OTN_OA": {
+        "sonic-optical-amplifier:sonic-optical-amplifier": {
+            "sonic-optical-amplifier:OTN_OA": {
+                "OTN_OA_LIST": [
+                    {
+                        "name": "OA0-0",
+                        "type": "EDFA",
+                        "target-gain": "15.0",
+                        "min-gain": "5.0",
+                        "max-gain": "25.0",
+                        "target-gain-tilt": "0.0",
+                        "gain-range": "LOW_GAIN_RANGE",
+                        "amp-mode": "CONSTANT_GAIN",
+                        "target-output-power": "23.0",
+                        "max-output-power": "23.0",
+                        "enabled": true,
+                        "fiber-type-profile": "SSMF"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VALID_OTN_OSC": {
+        "sonic-optical-amplifier:sonic-optical-amplifier": {
+            "sonic-optical-amplifier:OTN_OSC": {
+                "OTN_OSC_LIST": [
+                    {
+                        "interface": "OSC0-0"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_attenuator.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_attenuator.json
@@ -1,0 +1,17 @@
+{
+    "VALID_OTN_ATTENUATOR": {
+        "sonic-optical-attenuator:sonic-optical-attenuator": {
+            "sonic-optical-attenuator:OTN_ATTENUATOR": {
+                "OTN_ATTENUATOR_LIST": [
+                    {
+                        "name": "VOA0-0",
+                        "attenuation-mode": "CONSTANT_ATTENUATION",
+                        "target-output-power": "5.0",
+                        "attenuation": "10.0",
+                        "enabled": true
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-optical-amplifier.yang
+++ b/src/sonic-yang-models/yang-models/sonic-optical-amplifier.yang
@@ -12,15 +12,126 @@ module sonic-optical-amplifier {
 
   revision 2026-06-01 {
     description
-      "First revision, derived from openconfig-optical-amplifier.yang {version 2019-12-06}";
+      "First revision, derived from openconfig yang model";
+    reference
+      "openconfig-optical-amplifier.yang, version 2019-12-06";
+  }
+
+  typedef optical-amplifier-type {
+    type enumeration {
+      enum EDFA {
+        description
+          "Erbium doped fiber amplifer (EDFA)";
+      }
+      enum FORWARD_RAMAN {
+        description
+          "Forward pumping Raman amplifier";
+      }
+      enum BACKWARD_RAMAN {
+        description
+          "Backward pumping Raman amplifier";
+      }
+      enum HYBRID {
+        description
+          "Hybrid backward pumping Raman + EDFA amplifier";
+      }
+    }
+    description
+      "Type definition for different types of optical amplifiers.
+       Derived from the OPTICAL_AMPLIFIER_TYPE identity in
+       openconfig-optical-amplifier.yang";
+  }
+
+  typedef optical-amplifier-mode {
+    type enumeration {
+      enum CONSTANT_POWER {
+        description
+          "Constant power mode. In constant power mode, the amplifier
+           will maintain a constant output power by adjusting the
+           amplifier gain and/or related variable optical attenuators";
+      }
+      enum CONSTANT_GAIN {
+        description
+          "Constant gain mode. In constant gain mode, the amplifier
+           will maintain a constant amplifier gain";
+      }
+      enum DYNAMIC_GAIN {
+        description
+          "Dynamic gain mode. In dynamic gain mode, the amplifier will
+           automatically adjust gain to stay within parameters defined
+           by target-gain, min-gain and max-gain";
+      }
+    }
+    description
+      "Type definition for different types of optical amplifier
+       operating modes. Derived from the OPTICAL_AMPLIFIER_MODE
+       identity in openconfig-optical-amplifier.yang";
+  }
+
+  typedef gain-range {
+    type enumeration {
+      enum LOW_GAIN_RANGE {
+        description
+          "LOW gain range setting";
+      }
+      enum MID_GAIN_RANGE {
+        description
+          "MID gain range setting";
+      }
+      enum HIGH_GAIN_RANGE {
+        description
+          "HIGH gain range setting";
+      }
+      enum FIXED_GAIN_RANGE {
+        description
+          "Fixed or non-switched gain amplfier";
+      }
+    }
+    description
+      "Base type for expressing the gain range for a switched gain
+       amplifier. Derived from the GAIN_RANGE identity in
+       openconfig-optical-amplifier.yang";
+  }
+
+  typedef fiber-type-profile {
+    type enumeration {
+      enum DSF {
+        description
+          "Dispersion shifted fiber";
+      }
+      enum LEAF {
+        description
+          "Large effective area fiber";
+      }
+      enum SSMF {
+        description
+          "Standard single mode fiber";
+      }
+      enum TWC {
+        description
+          "True wave classic";
+      }
+      enum TWRS {
+        description
+          "True wave reduced slope";
+      }
+    }
+    description
+      "Type definition for different profiles of fiber types.
+       Derived from the FIBER_TYPE_PROFILE identity in
+       openconfig-optical-amplifier.yang";
   }
 
   container sonic-optical-amplifier {
+    description
+      "Top-level container for the OTN optical amplifier configuration";
     container OTN_OA {
       description
         "Enclosing container for list of amplifiers";
       list OTN_OA_LIST {
         key "name";
+        description
+          "List of optical amplifiers, keyed by amplifier name";
         leaf name {
           type string;
           description
@@ -28,14 +139,14 @@ module sonic-optical-amplifier {
              in the device";
         }
         leaf type {
-          type string;
+          type optical-amplifier-type;
           description
             "Type of the amplifier";
         }
         leaf target-gain {
           type decimal64 {
-            range "0..max";
             fraction-digits 2;
+            range "0..max";
           }
           units "dB";
           description
@@ -48,7 +159,7 @@ module sonic-optical-amplifier {
           type decimal64 {
             fraction-digits 2;
           }
-          units "dBm";
+          units "dB";
           description
             "The minimum allowed gain of the amplifier. This is used
              when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
@@ -60,7 +171,7 @@ module sonic-optical-amplifier {
           type decimal64 {
             fraction-digits 2;
           }
-          units "dBm";
+          units "dB";
           description
             "The maximum allowed gain of the amplifier. This is used
              when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
@@ -77,13 +188,13 @@ module sonic-optical-amplifier {
             "Gain tilt control";
         }
         leaf gain-range {
-          type string;
+          type gain-range;
           description
             "Selected gain range.  The gain range is a platform-defined
              value indicating the switched gain amplifier setting";
         }
         leaf amp-mode {
-          type string;
+          type optical-amplifier-mode;
           description
             "The operating mode of the amplifier";
         }
@@ -111,7 +222,7 @@ module sonic-optical-amplifier {
             "Turns power on / off to the amplifiers gain module.";
         }
         leaf fiber-type-profile {
-          type string;
+          type fiber-type-profile;
           description
             "The fiber type profile specifies details about the
              fiber type which are needed to accurately determine
@@ -125,6 +236,8 @@ module sonic-optical-amplifier {
         "Enclosing container for list of supervisory channels";
       list OTN_OSC_LIST {
         key "interface";
+        description
+          "List of optical supervisory channels, keyed by interface";
         leaf interface {
           type string;
           description

--- a/src/sonic-yang-models/yang-models/sonic-optical-amplifier.yang
+++ b/src/sonic-yang-models/yang-models/sonic-optical-amplifier.yang
@@ -1,0 +1,136 @@
+module sonic-optical-amplifier {
+  yang-version 1.1;
+  namespace "http://github.com/sonic-net/sonic-optical-amplifier";
+  prefix opt-amp;
+
+  organization
+    "SONiC";
+  contact
+    "SONiC";
+  description
+    "OTN_OA and OTN_OSC YANG Module for SONiC OS";
+
+  revision 2026-06-01 {
+    description
+      "First revision, derived from openconfig-optical-amplifier.yang {version 2019-12-06}";
+  }
+
+  container sonic-optical-amplifier {
+    container OTN_OA {
+      description
+        "Enclosing container for list of amplifiers";
+      list OTN_OA_LIST {
+        key "name";
+        leaf name {
+          type string;
+          description
+            "User-defined name assigned to identify a specific amplifier
+             in the device";
+        }
+        leaf type {
+          type string;
+          description
+            "Type of the amplifier";
+        }
+        leaf target-gain {
+          type decimal64 {
+            range "0..max";
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "Positive gain applied by the amplifier. This is used
+             when the amp-mode is in CONSTANT_GAIN or DYNAMIC_GAIN
+             mode to set the target gain that the amplifier should
+             achieve.";
+        }
+        leaf min-gain {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "The minimum allowed gain of the amplifier. This is used
+             when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
+             to prevent the gain from dropping below a desired threshold.
+             If left empty, the platform will apply a minimum gain based
+             on hardware specifications.";
+        }
+        leaf max-gain {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "The maximum allowed gain of the amplifier. This is used
+             when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
+             to prevent the gain from exceeding a desired threshold. If
+             left empty, the platform will apply a maximum gain based on
+             hardware specifications.";
+        }
+        leaf target-gain-tilt {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "Gain tilt control";
+        }
+        leaf gain-range {
+          type string;
+          description
+            "Selected gain range.  The gain range is a platform-defined
+             value indicating the switched gain amplifier setting";
+        }
+        leaf amp-mode {
+          type string;
+          description
+            "The operating mode of the amplifier";
+        }
+        leaf target-output-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "Output optical power of the amplifier.";
+        }
+        leaf max-output-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "The maximum optical output power of the amplifier. This
+             may be used to prevent the output power from exceeding a
+             desired threshold.";
+        }
+        leaf enabled {
+          type boolean;
+          description
+            "Turns power on / off to the amplifiers gain module.";
+        }
+        leaf fiber-type-profile {
+          type string;
+          description
+            "The fiber type profile specifies details about the
+             fiber type which are needed to accurately determine
+             the gain and perform efficient amplification. This is
+             only needed for Raman type amplifiers.";
+        }
+      }
+    }
+    container OTN_OSC {
+      description
+        "Enclosing container for list of supervisory channels";
+      list OTN_OSC_LIST {
+        key "interface";
+        leaf interface {
+          type string;
+          description
+            "Reference to an OSC interface";
+        }
+      }
+    }
+  }
+}

--- a/src/sonic-yang-models/yang-models/sonic-optical-attenuator.yang
+++ b/src/sonic-yang-models/yang-models/sonic-optical-attenuator.yang
@@ -12,15 +12,40 @@ module sonic-optical-attenuator {
 
   revision 2026-06-01 {
     description
-      "First revision, derived from openconfig-optical-attenuator.yang {version 2019-07-19}";
+      "First revision, derived from openconfig yang model";
+    reference
+      "openconfig-optical-attenuator.yang, version 2019-07-19";
+  }
+
+  typedef optical-attenuator-mode {
+    type enumeration {
+      enum CONSTANT_POWER {
+        description
+          "In constant power mode, the attenuator will apply
+           attenuation such as to maintain a constant output power";
+      }
+      enum CONSTANT_ATTENUATION {
+        description
+          "In constant attenuation mode, the attenuator will apply
+           a constant attenuation";
+      }
+    }
+    description
+      "Type definition for different types of optical attenuator
+       operating modes. Derived from the OPTICAL_ATTENUATOR_MODE
+       identity in openconfig-optical-attenuator.yang";
   }
 
   container sonic-optical-attenuator {
+    description
+      "Top-level container for the OTN optical attenuator configuration";
     container OTN_ATTENUATOR {
       description
         "Enclosing container for list of attenuators";
       list OTN_ATTENUATOR_LIST {
         key "name";
+        description
+          "List of optical attenuators, keyed by attenuator name";
         leaf name {
           type string;
           description
@@ -28,7 +53,7 @@ module sonic-optical-attenuator {
              in the device";
         }
         leaf attenuation-mode {
-          type string;
+          type optical-attenuator-mode;
           description
             "The operating mode of the attenuator";
         }
@@ -36,15 +61,15 @@ module sonic-optical-attenuator {
           type decimal64 {
             fraction-digits 2;
           }
-          units "dB";
+          units "dBm";
           description
             "Power level set on the output of attenuator.  This leaf is
              only relevant when in CONSTANT_POWER mode.";
         }
         leaf attenuation {
           type decimal64 {
-            range "0..max";
             fraction-digits 2;
+            range "0..max";
           }
           units "dB";
           description

--- a/src/sonic-yang-models/yang-models/sonic-optical-attenuator.yang
+++ b/src/sonic-yang-models/yang-models/sonic-optical-attenuator.yang
@@ -1,0 +1,64 @@
+module sonic-optical-attenuator {
+  yang-version 1.1;
+  namespace "http://github.com/sonic-net/sonic-optical-attenuator";
+  prefix opt-att;
+
+  organization
+    "SONiC";
+  contact
+    "SONiC";
+  description
+    "OTN_ATTENUATOR YANG Module for SONiC OS";
+
+  revision 2026-06-01 {
+    description
+      "First revision, derived from openconfig-optical-attenuator.yang {version 2019-07-19}";
+  }
+
+  container sonic-optical-attenuator {
+    container OTN_ATTENUATOR {
+      description
+        "Enclosing container for list of attenuators";
+      list OTN_ATTENUATOR_LIST {
+        key "name";
+        leaf name {
+          type string;
+          description
+            "User-defined name assigned to identify a specific attenuator
+             in the device";
+        }
+        leaf attenuation-mode {
+          type string;
+          description
+            "The operating mode of the attenuator";
+        }
+        leaf target-output-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "Power level set on the output of attenuator.  This leaf is
+             only relevant when in CONSTANT_POWER mode.";
+        }
+        leaf attenuation {
+          type decimal64 {
+            range "0..max";
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "Attenuation applied by the attenuator.  This leaf is only
+             relevant when in CONSTANT_ATTENUATION mode.";
+        }
+        leaf enabled {
+          type boolean;
+          description
+            "When true, attenuator is set to specified attenuation or varies to
+             maintain constant output power.  When false, the attenuator is set
+             max attenuation or blocked.";
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
These two sonic yang models are generated from `config` container of openconfig-optical-amplifier.yang and openconfig-optical-attenuator.yang. Two usages:
-  Since [commit](https://github.com/sonic-net/sonic-swss-common/commit/40feb900aabe97e1972b80cffc11cf2413c88fbd#diff-1d101f21f9c1725a002c730c62c84cf4b8615207602066783976e66435e13ff8), Config DB table names are autogenerated by sonic yang, instead of hard coded in schema.h. With this change, OTN-OA and OTN-ATTENUATOR table name would be generated in cfg_schema.h, which is included by schema.h.
- These two yang models will be imported to sonic-mgmt-common for NBI CVL (configuration validation layer)

---
_Reopens the review from #29, which was inadvertently auto-merged when the head commits were pushed to the base branch; the base has since been rewound._
